### PR TITLE
Fix for Ember 3.3.0

### DIFF
--- a/addon/templates/components/select-light.hbs
+++ b/addon/templates/components/select-light.hbs
@@ -8,15 +8,15 @@
   {{yield}}
 {{else}}
   {{#if isDeepOptions}}
-    {{#each options as | option |}}
-      <option value={{get option valueKey}} selected={{is-equal (get option valueKey) value}}>
-        {{get option displayKey}}
+    {{#each options as | opt |}}
+      <option value={{get opt valueKey}} selected={{is-equal (get opt valueKey) value}}>
+        {{get opt displayKey}}
       </option>
     {{/each}}
   {{else}}
-    {{#each options as | option |}}
-      <option value={{option}} selected={{is-equal option value}}>
-        {{option}}
+    {{#each options as | opt |}}
+      <option value={{opt}} selected={{is-equal opt value}}>
+        {{opt}}
       </option>
     {{/each}}
   {{/if}}


### PR DESCRIPTION
Probably related to [this issue](https://github.com/emberjs/ember.js/issues/16826), the use of `as |option|` in `ember-select-light/addon/templates/components/select-light.hbs` breaks this addon in Ember 3.3.0.