### PR TITLE
Don't crash if options is undefined

### DIFF
--- a/addon/components/select-light.js
+++ b/addon/components/select-light.js
@@ -20,7 +20,7 @@ export default Component.extend({
   displayKey: 'label',
 
   isDeepOptions: computed('options', 'valueKey', 'displayKey', function() {
-    if (this.options.length === 0 || !this.valueKey || !this.displayKey) return false;
+    if (!this.options || this.options.length === 0 || !this.valueKey || !this.displayKey) return false;
 
     let firstOptionValue = this.options[0][this.valueKey];
     let firstOptionDisplay = this.options[0][this.displayKey];


### PR DESCRIPTION
Prior to the last update, which made ember-select-light compatible with Ember 3.3.0, one could use the addon like this: `{{select-light options=(await availableUsers) ...}}` where the `options` may not be available until after the component has rendered.

This small fix restores compatibility with async / await options, whereas right now the component crashes if `options` is `undefined`.