### PR TITLE
Upgraded jquery dependency, removed sinopia registry bit, ssl for npm js reg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
     },
     "broccoli-debug": {
       "version": "0.6.5",
-      "resolved": "http://sinopia:4873/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
       "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
       "requires": {
         "broccoli-plugin": "^1.2.1",
@@ -4997,7 +4997,7 @@
     },
     "duplex": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/duplex/-/duplex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/duplex/-/duplex-1.0.0.tgz",
       "integrity": "sha1-arxcFuwX5MV4V4cnEmcAWQ06Ldo=",
       "dev": true
     },
@@ -5698,7 +5698,7 @@
     },
     "ember-cli-babel": {
       "version": "6.18.0",
-      "resolved": "http://sinopia:4873/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
       "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
       "requires": {
         "amd-name-resolver": "1.2.0",
@@ -5764,7 +5764,7 @@
     },
     "ember-cli-dependency-checker": {
       "version": "3.1.0",
-      "resolved": "http://sinopia:4873/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.1.0.tgz",
       "integrity": "sha512-Y/V2senOyIjQnZohYeZeXs59rWHI2m8KRF9IesMv1ypLRSc/h/QS6UX51wAyaZnxcgU6ljFXpqL5x38UxM3XzA==",
       "dev": true,
       "requires": {
@@ -5786,7 +5786,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://sinopia:4873/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -6406,7 +6406,7 @@
     },
     "ember-maybe-import-regenerator": {
       "version": "0.1.6",
-      "resolved": "http://sinopia:4873/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
       "integrity": "sha1-NdQYKK+m1qWbwNo85H80xXPXdso=",
       "dev": true,
       "requires": {
@@ -6476,7 +6476,7 @@
         },
         "regenerator-runtime": {
           "version": "0.9.6",
-          "resolved": "http://sinopia:4873/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
           "dev": true
         },
@@ -7418,6 +7418,12 @@
             "resolve": "^1.10.0",
             "resolve-package-path": "^1.0.11"
           }
+        },
+        "jquery": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
+          "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==",
+          "dev": true
         },
         "jsesc": {
           "version": "2.5.2",
@@ -8536,7 +8542,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -9103,7 +9109,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -9121,7 +9127,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -9139,7 +9145,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -9166,7 +9172,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -9184,7 +9190,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -10027,12 +10033,6 @@
         "is-object": "^1.0.1"
       }
     },
-    "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==",
-      "dev": true
-    },
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
@@ -10160,7 +10160,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -11544,7 +11544,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -12049,7 +12049,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -12986,7 +12986,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },


### PR DESCRIPTION
Bumps jquery to 3.4.0
Removes sinopia from being mentioned in at least one dependency.
npm registries have ssl url now.